### PR TITLE
Enable CloudFront access logging

### DIFF
--- a/infra/lib/CloudfrontConstruct.ts
+++ b/infra/lib/CloudfrontConstruct.ts
@@ -19,7 +19,7 @@ import {
 } from 'aws-cdk-lib/aws-cloudfront';
 import { HttpOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { Construct } from 'constructs';
-import { BlockPublicAccess, Bucket } from 'aws-cdk-lib/aws-s3';
+import { BlockPublicAccess, Bucket, ObjectOwnership } from 'aws-cdk-lib/aws-s3';
 import { FunctionUrl } from 'aws-cdk-lib/aws-lambda';
 
 export interface CloudfrontConstructProps {
@@ -58,8 +58,16 @@ export class CloudfrontConstruct extends Construct {
       removalPolicy: RemovalPolicy.DESTROY,
     });
 
+    // Access log bucket for CloudFront
+    const logBucket = new Bucket(this, `${id}-CfLogsBucket`, {
+      objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
     const appDist = new Distribution(this, 'AppDist', {
       certificate,
+      logBucket,
+      logFilePrefix: 'app-logs/',
       defaultBehavior: {
         origin: new HttpOrigin(siteBucket.bucketWebsiteDomainName, {
           protocolPolicy: OriginProtocolPolicy.HTTP_ONLY,
@@ -74,6 +82,8 @@ export class CloudfrontConstruct extends Construct {
 
     const serviceDist = new Distribution(this, 'ServiceDist', {
       certificate,
+      logBucket,
+      logFilePrefix: 'api-logs/',
       defaultBehavior: {
         origin: new HttpOrigin(lambdaOriginDomain, {
           protocolPolicy: OriginProtocolPolicy.HTTPS_ONLY,


### PR DESCRIPTION
## Summary
- Add a shared S3 log bucket with `BUCKET_OWNER_PREFERRED` object ownership (required for CF log delivery)
- Configure the app CloudFront distribution to write access logs with `app-logs/` prefix
- Configure the API CloudFront distribution to write access logs with `api-logs/` prefix

## Test plan
- [x] `cdk synth` succeeds
- [x] `cdk deploy` creates the log bucket and updates both distributions
- [x] Verify logs appear in the S3 bucket after some traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)